### PR TITLE
Fix stack corruption when removing list elements

### DIFF
--- a/src/AsyncWebSocket.cpp
+++ b/src/AsyncWebSocket.cpp
@@ -1221,9 +1221,15 @@ void AsyncWebSocket::_cleanBuffers()
 {
   AsyncWebLockGuard l(_lock);
 
-  for(AsyncWebSocketMessageBuffer * c: _buffers){
-    if(c && c->canDelete()){
-        _buffers.remove(c);
+  bool done = false;
+  while (!done) {
+    done = true;
+    for(AsyncWebSocketMessageBuffer * c: _buffers){
+      if(c && c->canDelete()){
+          _buffers.remove(c);
+          done = false;
+          break;
+      }
     }
   }
 }

--- a/src/WebRequest.cpp
+++ b/src/WebRequest.cpp
@@ -180,9 +180,15 @@ void AsyncWebServerRequest::_onData(void *buf, size_t len){
 
 void AsyncWebServerRequest::_removeNotInterestingHeaders(){
   if (_interestingHeaders.containsIgnoreCase("ANY")) return; // nothing to do
-  for(const auto& header: _headers){
-      if(!_interestingHeaders.containsIgnoreCase(header->name().c_str())){
-        _headers.remove(header);
+  bool done = false;
+  while (!done) {
+      done = true;
+      for(const auto& header: _headers){
+          if(!_interestingHeaders.containsIgnoreCase(header->name().c_str())){
+            _headers.remove(header);
+            done = false;
+            break;
+          }
       }
   }
 }


### PR DESCRIPTION
While diagnosing some stability issues after updating my ESPresense hosts I've come across two stack corruption issues in ESPAsyncWebServer:

```
(gdb) bt
#0  String::buffer (this=0x5c98b697)
    at /Users/gunnar/.platformio/packages/framework-arduinoespressif32/cores/esp32/WString.h:339
#1  String::c_str (this=0x5c98b697)
    at /Users/gunnar/.platformio/packages/framework-arduinoespressif32/cores/esp32/WString.h:248
#2  AsyncWebServerRequest::_removeNotInterestingHeaders (
    this=this@entry=0x3fcc8790)
    at .pio/libdeps/esp32c3-xiao/ESP Async WebServer/src/WebRequest.cpp:184
#3  0x42024264 in AsyncWebServerRequest::_parseLine (
    this=this@entry=0x3fcc8790)
    at .pio/libdeps/esp32c3-xiao/ESP Async WebServer/src/WebRequest.cpp:571
#4  0x42024342 in AsyncWebServerRequest::_onData (this=0x3fcc8790,
    buf=0x3fcc5685, len=2)
    at .pio/libdeps/esp32c3-xiao/ESP Async WebServer/src/WebRequest.cpp:123
#5  0x420245c0 in AsyncWebServerRequest::<lambda(void*, AsyncClient*, void*, size_t)>::operator() (len=<optimized out>, buf=<optimized out>,
    c=<optimized out>, r=<optimized out>, __closure=<optimized out>)
    at .pio/libdeps/esp32c3-xiao/ESP Async WebServer/src/WebRequest.cpp:76
#6  std::_Function_handler<void(void*, AsyncClient*, void*, unsigned int), AsyncWebServerRequest::AsyncWebServerRequest(AsyncWebServer*, AsyncClient*)::<lambda(void*, AsyncClient*, void*, size_t)> >::_M_invoke(const std::_Any_data &, void *&&, AsyncClient *&&, void *&&, unsigned int &&) (__functor=...,
    __args#0=<optimized out>, __args#1=<optimized out>,
    __args#2=<optimized out>, __args#3=<optimized out>)
    at /Users/gunnar/.platformio/packages/toolchain-riscv32-esp/riscv32-esp-elf/include/c++/8.4.0/bits/std_function.h:297
#7  0x42115ef4 in std::function<void (void*, AsyncClient*, void*, unsigned int)>::operator()(void*, AsyncClient*, void*, unsigned int) const (
    this=this@entry=0x3fcc8714, __args#0=<optimized out>,
    __args#1=<optimized out>, __args#1@entry=0x3fcc86bc,
    __args#2=<optimized out>, __args#3=<optimized out>)
    at /Users/gunnar/.platformio/packages/toolchain-riscv32-esp/riscv32-esp-elf/include/c++/8.4.0/bits/std_function.h:260
#8  0x42115f52 in AsyncClient::_recv (this=0x3fcc86bc, pcb=<optimized out>,
    pb=0x0, err=<optimized out>)
    at .pio/libdeps/esp32c3-xiao/AsyncTCP@src-39de97abf7348c44d4dda815b8aab0ae/src/AsyncTCP.cpp:968
#9  0x42115f96 in AsyncClient::_s_recv (arg=<optimized out>,
    pcb=<optimized out>, pb=<optimized out>, err=<optimized out>)
    at .pio/libdeps/esp32c3-xiao/AsyncTCP@src-39de97abf7348c44d4dda815b8aab0ae/src/AsyncTCP.cpp:1247
#10 0x421160e8 in _handle_async_event (e=0x3fcc0558)
    at .pio/libdeps/esp32c3-xiao/AsyncTCP@src-39de97abf7348c44d4dda815b8aab0ae/src/AsyncTCP.cpp:166
#11 0x42116156 in _async_service_task (pvParameters=<optimized out>)
    at .pio/libdeps/esp32c3-xiao/AsyncTCP@src-39de97abf7348c44d4dda815b8aab0ae/src/AsyncTCP.cpp:201
#12 0x40389912 in prvTaskExitError ()
    at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/freertos/port/riscv/port.c:133
Backtrace stopped: frame did not save the PC
```

and:

```
Thread 11 "async_tcp" received signal SIGTRAP, Trace/breakpoint trap.
[Switching to Thread 1070277520]
AsyncWebSocket::_cleanBuffers (this=this@entry=0x3fc91ee0 <ws>)
    at .pio/libdeps/esp32c3-xiao/ESP Async WebServer/src/AsyncWebSocket.cpp:1225
1225	    if(c && c->canDelete()){
(gdb) bt
#0  AsyncWebSocket::_cleanBuffers (this=this@entry=0x3fc91ee0 <ws>)
    at .pio/libdeps/esp32c3-xiao/ESP Async WebServer/src/AsyncWebSocket.cpp:1225
#1  0x42021e0a in AsyncWebSocket::textAll (this=0x3fc91ee0 <ws>,
    buffer=buffer@entry=0x3fcc69e0)
    at .pio/libdeps/esp32c3-xiao/ESP Async WebServer/src/AsyncWebSocket.cpp:957
#2  0x4200d290 in HttpWebServer::sendDataWs (client=client@entry=0x0)
    at src/HttpWebServer.cpp:103
#3  0x4200d2ce in HttpWebServer::onWsEvent (server=<optimized out>,
    client=<optimized out>, type=<optimized out>, arg=<optimized out>,
    data=<optimized out>, len=<optimized out>) at src/HttpWebServer.cpp:109
#4  0x4200308a in std::_Function_handler<void (AsyncWebSocket*, AsyncWebSocketClient*, AwsEventType, void*, unsigned char*, unsigned int), void (*)(AsyncWebSocket*, AsyncWebSocketClient*, AwsEventType, void*, unsigned char*, unsigned int)>::_M_invoke(std::_Any_data const&, AsyncWebSocket*&&, AsyncWebSocketClient*&&, AwsEventType&&, void*&&, unsigned char*&&, unsigned int&&) (__functor=...,
    __args#0=<optimized out>, __args#1=<optimized out>,
    __args#2=<optimized out>, __args#3=<optimized out>,
    __args#4=<optimized out>, __args#5=<optimized out>)
    at /Users/gunnar/.platformio/packages/toolchain-riscv32-esp/riscv32-esp-elf/include/c++/8.4.0/bits/std_function.h:88
#5  0x42021008 in std::function<void (AsyncWebSocket*, AsyncWebSocketClient*, AwsEventType, void*, unsigned char*, unsigned int)>::operator()(AsyncWebSocket*, AsyncWebSocketClient*, AwsEventType, void*, unsigned char*, unsigned int) const
    (this=<optimized out>, __args#0=<optimized out>, __args#1=<optimized out>,
    __args#1@entry=0x3fcc7230, __args#2=<optimized out>,
    __args#2@entry=WS_EVT_CONNECT, __args#3=<optimized out>,
    __args#3@entry=0x3fcc98d8, __args#4=<optimized out>, __args#4@entry=0x0,
    __args#5=<optimized out>, __args#5@entry=0)
    at /Users/gunnar/.platformio/packages/toolchain-riscv32-esp/riscv32-esp-elf/include/c++/8.4.0/bits/std_function.h:260
#6  0x4202103a in AsyncWebSocket::_handleEvent (this=<optimized out>,
    client=client@entry=0x3fcc7230, type=type@entry=WS_EVT_CONNECT,
    arg=arg@entry=0x3fcc98d8, data=data@entry=0x0, len=len@entry=0)
    at .pio/libdeps/esp32c3-xiao/ESP Async WebServer/src/AsyncWebSocket.cpp:864
#7  0x420211b0 in AsyncWebSocketClient::AsyncWebSocketClient (this=0x3fcc7230,
    request=0x3fcc98d8, server=<optimized out>)
    at .pio/libdeps/esp32c3-xiao/ESP Async WebServer/src/AsyncWebSocket.cpp:486
#8  0x420211ea in AsyncWebSocketResponse::_ack (this=0x3fcc6f8c,
    request=0x3fcc98d8, len=<optimized out>, time=<optimized out>)
    at .pio/libdeps/esp32c3-xiao/ESP Async WebServer/src/AsyncWebSocket.cpp:1291
#9  0x42022098 in AsyncWebServerRequest::_onAck (this=0x3fcc98d8, len=248,
    time=4)
    at .pio/libdeps/esp32c3-xiao/ESP Async WebServer/src/WebRequest.cpp:207
#10 0x420220c4 in AsyncWebServerRequest::<lambda(void*, AsyncClient*, size_t, uint32_t)>::operator() (time=<optimized out>, len=<optimized out>,
    c=<optimized out>, r=<optimized out>, __closure=<optimized out>)
    at .pio/libdeps/esp32c3-xiao/ESP Async WebServer/src/WebRequest.cpp:73
#11 std::_Function_handler<void(void*, AsyncClient*, unsigned int, long unsigned int), AsyncWebServerRequest::AsyncWebServerRequest(AsyncWebServer*, AsyncClient*)::<lambda(void*, AsyncClient*, size_t, uint32_t)> >::_M_invoke(const std::_Any_data &, void *&&, AsyncClient *&&, unsigned int &&, unsigned long &&) (
    __functor=..., __args#0=<optimized out>, __args#1=<optimized out>,
    __args#2=<optimized out>, __args#3=<optimized out>)
    at /Users/gunnar/.platformio/packages/toolchain-riscv32-esp/riscv32-esp-elf/include/c++/8.4.0/bits/std_function.h:297
#12 0x42115e4e in std::function<void (void*, AsyncClient*, unsigned int, unsigned long)>::operator()(void*, AsyncClient*, unsigned int, unsigned long) const (
    this=this@entry=0x3fcc9834, __args#0=<optimized out>,
    __args#1=<optimized out>, __args#1@entry=0x3fcc9804,
    __args#2=<optimized out>, __args#2@entry=248, __args#3=<optimized out>)
    at /Users/gunnar/.platformio/packages/toolchain-riscv32-esp/riscv32-esp-elf/include/c++/8.4.0/bits/std_function.h:260
#13 0x42115e8e in AsyncClient::_sent (this=0x3fcc9804, pcb=<optimized out>,
    len=<optimized out>)
    at .pio/libdeps/esp32c3-xiao/AsyncTCP@src-39de97abf7348c44d4dda815b8aab0ae/src/AsyncTCP.cpp:951
#14 0x42115ea4 in AsyncClient::_s_sent (arg=<optimized out>,
    pcb=<optimized out>, len=<optimized out>)
    at .pio/libdeps/esp32c3-xiao/AsyncTCP@src-39de97abf7348c44d4dda815b8aab0ae/src/AsyncTCP.cpp:1259
#15 0x42116106 in _handle_async_event (e=0x3fcacdc4)
    at .pio/libdeps/esp32c3-xiao/AsyncTCP@src-39de97abf7348c44d4dda815b8aab0ae/src/AsyncTCP.cpp:172
#16 0x4211615c in _async_service_task (pvParameters=<optimized out>)
    at .pio/libdeps/esp32c3-xiao/AsyncTCP@src-39de97abf7348c44d4dda815b8aab0ae/src/AsyncTCP.cpp:201
#17 0x40389912 in prvTaskExitError ()
    at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/freertos/port/riscv/port.c:133
Backtrace stopped: frame did not save the PC
```

Both times list elements are removed from a list while iterating over that list. This invalidates the current element and depending on the exact stack layout the `next` pointer may end up as garbage before it's being used to step to the next list element.

Apparently several other people have already encountered this, but the bugs were never fixed upstream:

https://github.com/me-no-dev/ESPAsyncWebServer/issues/837
https://github.com/me-no-dev/ESPAsyncWebServer/issues?q=_removeNotInterestingHeaders